### PR TITLE
v0.3.3 CircleBuffer fix, add zstd binaries to package

### DIFF
--- a/src/Esper.Accelerator/Esper.Accelerator.csproj
+++ b/src/Esper.Accelerator/Esper.Accelerator.csproj
@@ -14,7 +14,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>0.3.1</PackageVersion>
+    <PackageVersion>0.3.3</PackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Esper.Misaka/Esper.Misaka.csproj
+++ b/src/Esper.Misaka/Esper.Misaka.csproj
@@ -15,7 +15,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>0.3.1</PackageVersion>
+    <PackageVersion>0.3.3</PackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Esper.Test/EsperTests.cs
+++ b/src/Esper.Test/EsperTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Esper.Test
+{
+    public class EsperTests
+    {
+        [Test]
+        public void TestCircleBuffer()
+        {
+            // Test some operations with circlebuffer
+            CircleBuffer<byte> cb = new CircleBuffer<byte>(100);
+            Random r = new Random();
+            byte[] a = new byte[60];
+            r.NextBytes(a);
+            foreach (byte b in a)
+                cb.Add(b);
+            List<byte> list = new List<byte>(a);
+            Assert.IsTrue(cb.SequenceEqual(list));
+            cb.RemoveAt(40);
+            list.RemoveAt(40);
+            Assert.IsTrue(cb.SequenceEqual(list));
+            cb.RemoveAt(10);
+            list.RemoveAt(10);
+            Assert.IsTrue(cb.SequenceEqual(list));
+            cb.Insert(5, 10);
+            list.Insert(5, 10);
+            Assert.IsTrue(cb.SequenceEqual(list));
+            cb.Insert(50, 60);
+            list.Insert(50, 60);
+            Assert.IsTrue(cb.SequenceEqual(list));
+        }
+
+        [Test]
+        public void TestMultiBufferStream()
+        {
+            // Test a bunch of random location reads
+            Random r = new Random();
+            byte[] a = new byte[4096*4];
+            r.NextBytes(a);
+            MemoryStream ms = new MemoryStream(a);
+            using MultiBufferStream mbs = new MultiBufferStream(ms, true, 8, 128);
+            mbs.LargeReadOverride = false;
+            byte[] temp = new byte[256];
+            for (int i = 0; i < 128; i++)
+            {
+                int position = 16 * (r.Next() % 256) * 4;
+                mbs.Position = position;
+                int read = mbs.Read(temp, 0, 256);
+                //Console.WriteLine($"{i} {position} {read}");
+                Assert.AreEqual(new ArraySegment<byte>(a, position, read), new ArraySegment<byte>(temp, 0, read));
+            }
+
+            // Test full read
+            mbs.Position = 0;
+            MemoryStream ms2 = new MemoryStream();
+            mbs.CopyTo(ms2);
+            ms2.TryGetBuffer(out ArraySegment<byte> ms2b);
+            Assert.AreEqual(new ArraySegment<byte>(a), ms2b);
+        }
+
+        [Test]
+        public void TestMultiBufferStream2()
+        {
+            // Test a bunch of random location reads
+            Random r = new Random();
+            byte[] a = new byte[4096*4];
+            r.NextBytes(a);
+            MemoryStream ms = new MemoryStream(a);
+            using MultiBufferStream mbs = new MultiBufferStream(ms, false, 8, 128);
+            mbs.LargeReadOverride = false;
+            byte[] temp = new byte[256];
+            for (int i = 0; i < 128; i++)
+            {
+                int position = 16 * (r.Next() % 256) * 4;
+                mbs.Position = position;
+                int read = mbs.Read(temp, 0, 256);
+                //Console.WriteLine($"{i} {position} {read}");
+                Assert.AreEqual(new ArraySegment<byte>(a, position, read), new ArraySegment<byte>(temp, 0, read));
+            }
+
+            // Test full read
+            mbs.Position = 0;
+            MemoryStream ms2 = new MemoryStream();
+            mbs.CopyTo(ms2);
+            ms2.TryGetBuffer(out ArraySegment<byte> ms2b);
+            Assert.AreEqual(new ArraySegment<byte>(a), ms2b);
+        }
+    }
+}

--- a/src/Esper.Zstandard/Esper.Zstandard.csproj
+++ b/src/Esper.Zstandard/Esper.Zstandard.csproj
@@ -15,7 +15,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>0.3.2</PackageVersion>
+    <PackageVersion>0.3.3</PackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8</LangVersion>
   </PropertyGroup>

--- a/src/Esper.Zstandard/Esper.Zstandard.csproj
+++ b/src/Esper.Zstandard/Esper.Zstandard.csproj
@@ -21,19 +21,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="lib\win_x64\zstd.dll">
+    <None Include="lib\win_x64\zstd.dll" Pack="true" PackagePath="lib/netstandard2.0/lib/win_x64">
       <Link>win_x64\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="lib\win_x86\zstd.dll">
+    <None Include="lib\win_x86\zstd.dll" Pack="true" PackagePath="lib/netstandard2.0/lib/win_x86">
       <Link>win_x86\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="lib\linux_x64\libzstd.so.1.4.4">
+    <None Include="lib\linux_x64\libzstd.so.1.4.4" Pack="true" PackagePath="lib/netstandard2.0/lib/linux_x64">
       <Link>linux_x64\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="lib\osx_x64\libzstd.1.4.4.dylib">
+    <None Include="lib\osx_x64\libzstd.1.4.4.dylib" Pack="true" PackagePath="lib/netstandard2.0/lib/osx_x64">
       <Link>osx_x64\%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Esper/CircleBuffer.cs
+++ b/src/Esper/CircleBuffer.cs
@@ -54,7 +54,7 @@ namespace Esper
             {
                 // Better to move elements below
                 for (int j = i; j > 0; j--) _entries[Index(j)] = _entries[Index(j - 1)];
-                _entries[Index(_first)] = default!;
+                _entries[_first] = default!;
                 // Move bottom up
                 _first = (_first + 1) % Capacity;
             }

--- a/src/Esper/Esper.csproj
+++ b/src/Esper/Esper.csproj
@@ -14,7 +14,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageVersion>0.3.2</PackageVersion>
+    <PackageVersion>0.3.3</PackageVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>8</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
-CircleBuffer.RemoveAt fixed
-Zstd binaries added to nuget package

https://www.nuget.org/packages/Esper/0.3.3
https://www.nuget.org/packages/Esper.Accelerator/0.3.3
https://www.nuget.org/packages/Esper.Misaka/0.3.3
https://www.nuget.org/packages/Esper.Zstandard/0.3.3